### PR TITLE
improve docker resilience for github mcp across platforms

### DIFF
--- a/src/tools/github-mcp/index.ts
+++ b/src/tools/github-mcp/index.ts
@@ -2,7 +2,6 @@ import { createLogger, createMcpClientTool } from '@autonomys/agent-core';
 import { StructuredToolInterface } from '@langchain/core/tools';
 import { StdioServerParameters } from '@modelcontextprotocol/sdk/client/stdio.js';
 
-
 export type Toolset =
   | 'repos'
   | 'issues'
@@ -18,10 +17,10 @@ export const createGitHubTools = async (
 ): Promise<StructuredToolInterface[]> => {
   // Common Docker install locations
   const extraPaths = [
-    '/usr/local/bin',           // macOS, Linux (Homebrew, standard)
-    '/opt/homebrew/bin',        // macOS (Apple Silicon Homebrew)
+    '/usr/local/bin', // macOS, Linux (Homebrew, standard)
+    '/opt/homebrew/bin', // macOS (Apple Silicon Homebrew)
     'C:\\Program Files\\Docker\\Docker\\resources\\bin', // Windows default
-    'C:\\ProgramData\\DockerDesktop\\version-bin',       // Windows (newer Docker Desktop)
+    'C:\\ProgramData\\DockerDesktop\\version-bin', // Windows (newer Docker Desktop)
   ];
 
   // Build a platform-appropriate PATH string


### PR DESCRIPTION
This pull request enhances the `src/tools/github-mcp/index.ts` file by improving Docker path handling and adding a check for Docker installation. These changes ensure better cross-platform compatibility and provide clearer error handling when Docker is not properly set up.

### Improvements to Docker path handling and validation:

* **Added Docker installation check**: Introduced a `execSync` call to verify Docker is installed and accessible in the `PATH`. If not, an error is thrown with a clear message.
* **Enhanced `PATH` management**: Added logic to construct a platform-specific `PATH` string by appending common Docker installation directories for macOS, Linux, and Windows. This ensures the application can locate Docker even if it's installed in non-standard locations. [[1]](diffhunk://#diff-f4d206e1cebdd460f35b209206277d80fa7d0ea13d3d950b02fcdf1760058fccR31-R79) [[2]](diffhunk://#diff-f4d206e1cebdd460f35b209206277d80fa7d0ea13d3d950b02fcdf1760058fccL50-R92)

### Codebase adjustments:

* **Updated environment variables**: Modified the environment passed to the `spawn` function to include the updated `PATH` string, ensuring the Docker command can be executed successfully. [[1]](diffhunk://#diff-f4d206e1cebdd460f35b209206277d80fa7d0ea13d3d950b02fcdf1760058fccR31-R79) [[2]](diffhunk://#diff-f4d206e1cebdd460f35b209206277d80fa7d0ea13d3d950b02fcdf1760058fccL50-R92)
* **Imported `execSync`**: Added the `execSync` import from the `child_process` module to enable synchronous execution of the Docker version check.