### PR TITLE
change stopCounterLimit to 1

### DIFF
--- a/src/agents/github/githubAgent.ts
+++ b/src/agents/github/githubAgent.ts
@@ -40,7 +40,7 @@ const createGithubAgentConfig = async (
     namespace: options?.namespace ?? defaultGithubOptions.namespace,
     toolsets: options?.toolsets ?? defaultGithubOptions.toolsets,
     recursionLimit: options?.recursionLimit ?? 100,
-    stopCounterLimit: options?.stopCounterLimit ?? 3,
+    stopCounterLimit: options?.stopCounterLimit ?? 1,
     githubToken,
   };
 

--- a/src/config/orchestrator.ts
+++ b/src/config/orchestrator.ts
@@ -23,6 +23,7 @@ export const createOrchestratorConfig = async (configInstance: ConfigInstance, t
     experienceConfig,
     monitoringConfig,
     prompts,
+    stopCounterLimit: 1,
     characterDataPathConfig: {
       dataPath: characterPath,
     },

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -48,6 +48,7 @@ export const createTwitterTool = async (configInstance: ConfigInstance) => {
     postTweets: twitterConfig.POST_TWEETS,
     experienceConfig,
     monitoringConfig,
+    stopCounterLimit: 1,
     modelConfigurations: twitterConfig.model_configurations,
   });
   return twitterAgent;


### PR DESCRIPTION
This pull request introduces a change to standardize the `stopCounterLimit` configuration across multiple components in the codebase. The limit has been reduced to 1 to ensure consistent behavior.

### Configuration Standardization:

* [`src/agents/github/githubAgent.ts`](diffhunk://#diff-c4d6c7fa4f0bc11ca17d85f9ebc27670b5120d7de0f0c856cba67de91d328b06L43-R43): Updated the `stopCounterLimit` default value from 3 to 1 in the `createGithubAgentConfig` function.
* [`src/config/orchestrator.ts`](diffhunk://#diff-55a86859c6c40e5e159e183d351ecc64e461ce20864ca9d515259d42be9d80dbR26): Added a `stopCounterLimit` property with a value of 1 in the `createOrchestratorConfig` function.
* [`src/tools.ts`](diffhunk://#diff-7b381cf3e55be36005a71f5ebd2e0e432259db371daf7f95de6e61a34aa447fdR51): Added a `stopCounterLimit` property with a value of 1 in the `createTwitterTool` function.